### PR TITLE
support boolean mapping

### DIFF
--- a/src/MySQL/ModelObject.php
+++ b/src/MySQL/ModelObject.php
@@ -42,6 +42,7 @@ abstract class ModelObject {
 
                 switch($class) {
                     case 'Integer': $this->$property = (Integer) $value; break;
+                    case 'Boolean': $this->$property = (bool) $value; break;
                     case 'Float': $this->$property = (Float) $value; break;
                     case 'String': $this->$property = (String) $value; break;
                     case 'JSON': $this->$property = is_string($value) ? json_decode($value) : $value; break;
@@ -103,6 +104,7 @@ abstract class ModelObject {
 
                 switch($class) {
                     case 'Integer':
+                    case 'Boolean':
                     case 'Float':
                     case 'String':
                     case 'DateTime':
@@ -159,6 +161,7 @@ abstract class ModelObject {
 
                 switch($class) {
                     case 'Integer': $array[$property] = (Integer) $this->$property; break;
+                    case 'Boolean': $array[$property] = (bool) $this->$property; break;
                     case 'Float': $array[$property] = (Float) $this->$property; break;
                     case 'String': $array[$property] = (String) $this->$property; break;
                     case 'DateTime': $array[$property] = $this->$property->format('Y-m-d H:i:s'); break;
@@ -198,6 +201,9 @@ abstract class ModelObject {
                 case 'Integer':
                     $params[] = ['value' => (Integer) $this->id, 'type' => \PDO::PARAM_INT];
                     break;
+                case 'bool':
+                    $params[] = ['value' => (bool) $this->id, 'type' => \PDO::PARAM_INT];
+                    break;
                 case 'String':
                     $params[] = ['value' => (String) $this->id, 'type' => \PDO::PARAM_STR];
                     break;
@@ -234,6 +240,10 @@ abstract class ModelObject {
                     case 'Integer':
                         $fields[] = '`'.$property.'`';
                         $params[] = ['value' => (Integer) $this->$property, 'type' => \PDO::PARAM_INT];
+                        break;
+                    case 'Boolean':
+                        $fields[] = '`'.$property.'`';
+                        $params[] = ['value' => (bool) $this->$property, 'type' => \PDO::PARAM_INT];
                         break;
                     case 'Float':
                         $fields[] = '`'.$property.'`';
@@ -307,6 +317,9 @@ abstract class ModelObject {
                 case 'Integer':
                     $params[] = ['value' => (Integer) $this->id, 'type' => \PDO::PARAM_INT];
                     break;
+                case 'Boolean':
+                    $params[] = ['value' => (bool) $this->id, 'type' => \PDO::PARAM_INT];
+                    break;
                 case 'String':
                     $params[] = ['value' => (String) $this->id, 'type' => \PDO::PARAM_STR];
                     break;
@@ -321,6 +334,9 @@ abstract class ModelObject {
                 switch(static::$properties['id']['class']) {
                     case 'Integer':
                         $params[] = ['value' => (Integer) $this->id, 'type' => \PDO::PARAM_INT];
+                        break;
+                    case 'Boolean':
+                        $params[] = ['value' => (bool) $this->id, 'type' => \PDO::PARAM_INT];
                         break;
                     case 'String':
                         $params[] = ['value' => (String) $this->id, 'type' => \PDO::PARAM_STR];

--- a/src/MySQL/ModelObject.php
+++ b/src/MySQL/ModelObject.php
@@ -42,7 +42,7 @@ abstract class ModelObject {
 
                 switch($class) {
                     case 'Integer': $this->$property = (Integer) $value; break;
-                    case 'Boolean': $this->$property = (bool) $value; break;
+                    case 'Boolean': $this->$property = (Boolean) $value; break;
                     case 'Float': $this->$property = (Float) $value; break;
                     case 'String': $this->$property = (String) $value; break;
                     case 'JSON': $this->$property = is_string($value) ? json_decode($value) : $value; break;
@@ -161,7 +161,7 @@ abstract class ModelObject {
 
                 switch($class) {
                     case 'Integer': $array[$property] = (Integer) $this->$property; break;
-                    case 'Boolean': $array[$property] = (bool) $this->$property; break;
+                    case 'Boolean': $array[$property] = (Boolean) $this->$property; break;
                     case 'Float': $array[$property] = (Float) $this->$property; break;
                     case 'String': $array[$property] = (String) $this->$property; break;
                     case 'DateTime': $array[$property] = $this->$property->format('Y-m-d H:i:s'); break;
@@ -200,9 +200,6 @@ abstract class ModelObject {
             switch(static::$properties['id']['class']) {
                 case 'Integer':
                     $params[] = ['value' => (Integer) $this->id, 'type' => \PDO::PARAM_INT];
-                    break;
-                case 'bool':
-                    $params[] = ['value' => (bool) $this->id, 'type' => \PDO::PARAM_INT];
                     break;
                 case 'String':
                     $params[] = ['value' => (String) $this->id, 'type' => \PDO::PARAM_STR];
@@ -243,7 +240,7 @@ abstract class ModelObject {
                         break;
                     case 'Boolean':
                         $fields[] = '`'.$property.'`';
-                        $params[] = ['value' => (bool) $this->$property, 'type' => \PDO::PARAM_INT];
+                        $params[] = ['value' => (Boolean) $this->$property, 'type' => \PDO::PARAM_INT];
                         break;
                     case 'Float':
                         $fields[] = '`'.$property.'`';
@@ -317,9 +314,6 @@ abstract class ModelObject {
                 case 'Integer':
                     $params[] = ['value' => (Integer) $this->id, 'type' => \PDO::PARAM_INT];
                     break;
-                case 'Boolean':
-                    $params[] = ['value' => (bool) $this->id, 'type' => \PDO::PARAM_INT];
-                    break;
                 case 'String':
                     $params[] = ['value' => (String) $this->id, 'type' => \PDO::PARAM_STR];
                     break;
@@ -334,9 +328,6 @@ abstract class ModelObject {
                 switch(static::$properties['id']['class']) {
                     case 'Integer':
                         $params[] = ['value' => (Integer) $this->id, 'type' => \PDO::PARAM_INT];
-                        break;
-                    case 'Boolean':
-                        $params[] = ['value' => (bool) $this->id, 'type' => \PDO::PARAM_INT];
                         break;
                     case 'String':
                         $params[] = ['value' => (String) $this->id, 'type' => \PDO::PARAM_STR];

--- a/src/MySQL/Request.php
+++ b/src/MySQL/Request.php
@@ -306,7 +306,7 @@ abstract class Request extends AbstractRequest {
                 $this->bindings[] = ['value' => (Float) $value, 'type' => \PDO::PARAM_STR];
                 break;
             case 'Boolean':
-                $this->bindings[] = ['value' => (bool) $value, 'type' => \PDO::PARAM_INT];
+                $this->bindings[] = ['value' => (Boolean) $value, 'type' => \PDO::PARAM_INT];
                 break;
             case 'Integer':
             case 'Timestamp':

--- a/src/MySQL/Request.php
+++ b/src/MySQL/Request.php
@@ -51,7 +51,7 @@ abstract class Request extends AbstractRequest {
         if($distinct) {
             $statement .= 'DISTINCT ';
         }
-        
+
         $statement .= 'T0.`'.$field.'`) AS C';
         $statement .= $this->generateSQLJoins();
         $statement .= $this->generateSQLWhere();
@@ -286,7 +286,7 @@ abstract class Request extends AbstractRequest {
         if(is_subclass_of($propertyClass, self::OBJECTS_CLASS)) {
             $propertyClass = $propertyClass::getPropertyClass('id');
             $value = is_subclass_of($value, self::OBJECTS_CLASS) ? $value->id : $value;
-        } 
+        }
         else if(enum_exists($propertyClass)) {
             if($value instanceof $propertyClass) {
                 $value = $value->value;
@@ -304,6 +304,9 @@ abstract class Request extends AbstractRequest {
                 break;
             case 'Float':
                 $this->bindings[] = ['value' => (Float) $value, 'type' => \PDO::PARAM_STR];
+                break;
+            case 'Boolean':
+                $this->bindings[] = ['value' => (bool) $value, 'type' => \PDO::PARAM_INT];
                 break;
             case 'Integer':
             case 'Timestamp':


### PR DESCRIPTION
sans le mapping boolean, on ne peux pas utiliser le ModelObject->asArray() dirrectement en retour de web service qui doivent renvoyer des boolean.